### PR TITLE
Update reference-connect-ports.md

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-ports.md
+++ b/articles/active-directory/hybrid/reference-connect-ports.md
@@ -32,6 +32,7 @@ This table describes the ports and protocols that are required for communication
 | Kerberos |88 (TCP/UDP) |Kerberos authentication to the AD forest. |
 | MS-RPC |135 (TCP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
 | LDAP |389 (TCP/UDP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
+| Global Catalog | 3268 (TCP) | Used by Seamless SSO to query the Global Catalog in the forest prior to create a computer account in the Domain. |
 | SMB | 445 (TCP) |Used by Seamless SSO to create a computer account in the AD forest. |
 | LDAP/SSL |636 (TCP/UDP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using TLS. |
 | RPC |49152- 65535 (Random high RPC Port)(TCP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |


### PR DESCRIPTION
While working at this SR , during troubleshooting we could verify that when adding a new Domain to AD Connect configuration, at the creation of the SSO computer object at this new connected domain, AD Connect will query the global catalog. This requirement is not documented hence this change proposal.